### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ DerivedData
 *.hmap
 *.ipa
 
+# Swift Package Manager
+.swiftpm
+
 # Bundler
 .bundle
 

--- a/KeyboardLayoutGuide.podspec
+++ b/KeyboardLayoutGuide.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
 s.name             = "KeyboardLayoutGuide"
-s.version          = "0.7.0"
+s.version          = "0.7.1"
 s.summary          = "Enables you to set up Autolayout constraints directly between your views
 and the iOS keyboard."
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "KeyboardLayoutGuide",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "KeyboardLayoutGuide",
+            targets: ["KeyboardLayoutGuide"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/johnpatrickmorgan/LifecycleHooks.git", from: "0.6.1")
+    ],
+    targets: [
+        .target(
+            name: "KeyboardLayoutGuide",
+            dependencies: [],
+            path: "Pod/Classes"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ Although constraints will be added at runtime, you still need to satisfy Interfa
 
 ### CocoaPods
 
-KeyboardLayoutGuide is available through [CocoaPods](http://cocoapods.org). To install
-it, simply add the following line to your Podfile:
+KeyboardLayoutGuide is available through [CocoaPods](http://cocoapods.org). To install it, simply add the following line to your Podfile:
 
 ```ruby
 pod "KeyboardLayoutGuide"
@@ -61,6 +60,16 @@ Add the following to your Cartfile:
 
 ```
 github "johnpatrickmorgan/KeyboardLayoutGuide"
+```
+
+### Swift Package Manager
+
+Adding the following to the `dependencies` array of your `Package.swift`:
+
+```swift
+dependencies: [
+	.package(url: "https://github.com/johnpatrickmorgan/KeyboardLayoutGuide.git", from: "0.7.1")
+]
 ```
 
 ## License


### PR DESCRIPTION
This PR requires johnpatrickmorgan/LifecycleHooks#5 to be merged as well otherwise the dependencies won't resolve.

Same as the other PR—you will need to make sure to pull in the tag (tagged in my repo as 0.7.1)